### PR TITLE
Successfully deployed to Heroku

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
       <li>{{category}}: {{numProjects}} Projects</li>
     </script>
     <script id="repo-template" type="text/x-handlebars-template">
-      <h2><a href="{{url}}">{{name}}</a></h2>
+      <h2 class="repoTitle"><a href="{{url}}">{{name}}</a></h2>
       <h4>Language: {{language}}</h4>
       <h6>Created on: {{created_at}}</h6>
       <h6>Last Updated: {{updated_at}}</h6>


### PR DESCRIPTION
Successfully deployed to Heroku and implemented loading of github repos via the API.  I decided to add the repos to a distinct third page.  That way, I can keep the home page as a showcase of my best projects, and write more detailed explanations of them.  The repos "tab" pulls the repo list from my github directory via the API.  I'm now thinking of changing titles of the repos to allow for easier filtering on the repo page.

 For example, I could change all repos that are a part of Codefellows classes to a title with a "CF-" prefix, all personal projects could have a prefix of, "Per-", etc.  Organization of the github repos this way would allow for the application of filtering or sorting functions on the data pulled from the website.  Another example - any title containing "DRAFT" could be excluded from the repo list.

Need to begin styling everything.